### PR TITLE
Add zIndex to device location marker

### DIFF
--- a/app/src/components/Map.js
+++ b/app/src/components/Map.js
@@ -109,7 +109,7 @@ const Map = () => {
 
             navigator.geolocation.getCurrentPosition(pos => {
                 let position = new window.google.maps.LatLng(pos.coords.latitude, pos.coords.longitude);
-                marker = new window.google.maps.Marker({ position, map, icon: iconImage });
+                marker = new window.google.maps.Marker({ position, map, icon: iconImage, optimized: false, zIndex: 99999999 });
                 marker.setMap(map);
 
                 navigator.geolocation.watchPosition(


### PR DESCRIPTION
Device icon should always stay on top of all other geo features.