### PR TITLE
Set marker clickable to false, allow click events only for geo features

### DIFF
--- a/app/src/components/Map.js
+++ b/app/src/components/Map.js
@@ -109,7 +109,14 @@ const Map = () => {
 
             navigator.geolocation.getCurrentPosition(pos => {
                 let position = new window.google.maps.LatLng(pos.coords.latitude, pos.coords.longitude);
-                marker = new window.google.maps.Marker({ position, map, icon: iconImage, optimized: false, zIndex: 99999999 });
+                marker = new window.google.maps.Marker({
+                    position,
+                    map,
+                    icon: iconImage,
+                    optimized: false,
+                    zIndex: 9999,
+                    clickable: false
+                });
                 marker.setMap(map);
 
                 navigator.geolocation.watchPosition(


### PR DESCRIPTION
We want the user position marker to be visually on the top data layer, but click events should go through the lowest layer of the geo feature items. 